### PR TITLE
planner/core: fix column privilege for aggregation

### DIFF
--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -871,6 +871,63 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 		ans []visitInfo
 	}{
 		{
+			sql: "select count(a) from t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", nil},
+			},
+		},
+		{
+			sql: "select count(1) from t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", nil},
+				{mysql.SelectPriv, "test", "t", "b", nil},
+				{mysql.SelectPriv, "test", "t", "c", nil},
+				{mysql.SelectPriv, "test", "t", "d", nil},
+				{mysql.SelectPriv, "test", "t", "e", nil},
+				{mysql.SelectPriv, "test", "t", "c_str", nil},
+				{mysql.SelectPriv, "test", "t", "d_str", nil},
+				{mysql.SelectPriv, "test", "t", "e_str", nil},
+				{mysql.SelectPriv, "test", "t", "f", nil},
+				{mysql.SelectPriv, "test", "t", "g", nil},
+				{mysql.SelectPriv, "test", "t", "h", nil},
+				{mysql.SelectPriv, "test", "t", "i_date", nil},
+			},
+		},
+		{
+			sql: "select count(*) from t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", nil},
+				{mysql.SelectPriv, "test", "t", "b", nil},
+				{mysql.SelectPriv, "test", "t", "c", nil},
+				{mysql.SelectPriv, "test", "t", "d", nil},
+				{mysql.SelectPriv, "test", "t", "e", nil},
+				{mysql.SelectPriv, "test", "t", "c_str", nil},
+				{mysql.SelectPriv, "test", "t", "d_str", nil},
+				{mysql.SelectPriv, "test", "t", "e_str", nil},
+				{mysql.SelectPriv, "test", "t", "f", nil},
+				{mysql.SelectPriv, "test", "t", "g", nil},
+				{mysql.SelectPriv, "test", "t", "h", nil},
+				{mysql.SelectPriv, "test", "t", "i_date", nil},
+			},
+		},
+		{
+			sql: "select * from t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", nil},
+				{mysql.SelectPriv, "test", "t", "b", nil},
+				{mysql.SelectPriv, "test", "t", "c", nil},
+				{mysql.SelectPriv, "test", "t", "d", nil},
+				{mysql.SelectPriv, "test", "t", "e", nil},
+				{mysql.SelectPriv, "test", "t", "c_str", nil},
+				{mysql.SelectPriv, "test", "t", "d_str", nil},
+				{mysql.SelectPriv, "test", "t", "e_str", nil},
+				{mysql.SelectPriv, "test", "t", "f", nil},
+				{mysql.SelectPriv, "test", "t", "g", nil},
+				{mysql.SelectPriv, "test", "t", "h", nil},
+				{mysql.SelectPriv, "test", "t", "i_date", nil},
+			},
+		},
+		{
 			sql: "select a from t",
 			ans: []visitInfo{
 				{mysql.SelectPriv, "test", "t", "a", nil},
@@ -932,7 +989,7 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 		{
 			sql: "select a, sum(e) from t group by a",
 			ans: []visitInfo{
-				// {mysql.SelectPriv, "test", "t", "e", nil},
+				{mysql.SelectPriv, "test", "t", "e", nil},
 				{mysql.SelectPriv, "test", "t", "a", nil},
 			},
 		},


### PR DESCRIPTION

### What problem does this PR solve?

![image](https://user-images.githubusercontent.com/1420062/109246592-7eb35a00-781d-11eb-9466-adba054e6081.png)


Problem Summary:

Privilege check for `select count(*)  from t` is wrong.

### What is changed and how it works?

What's Changed:

Check column privilege for aggregation.

How it Works:



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

